### PR TITLE
Fix nth argument function

### DIFF
--- a/05_Patterns_And_Best_Practices.md
+++ b/05_Patterns_And_Best_Practices.md
@@ -1812,7 +1812,7 @@ end
 
 -- Get nth argument
 local function GetArg(n, ...)
-    return select(n, ...);
+    return (select(n, ...));
 end
 
 -- Get all args starting from n


### PR DESCRIPTION
Ensure GetArg function works as described. Both the get nth arg function and the get args starting from n function were identical.

https://www.lua.org/pil/5.1.html
> You can force a call to return exactly one result by enclosing it in an extra pair of parentheses

Side note, I could be wrong but I think the use of semicolons is inconsistent between files. The earlier files like [UI_Framework](https://github.com/Amadeus-/WoWAddonDevGuide/blob/master/03_UI_Framework.md) and [Addon_Structure](https://github.com/Amadeus-/WoWAddonDevGuide/blob/master/04_Addon_Structure.md) don't use semicolons. They are less code-focused though, so maybe that explains it. I did not do an exhaustive look, I was just surprised by the semicolons in this file. It might be worth another pass to standardise.